### PR TITLE
build(prettier): update config to fix silent error

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "plugins": ["prettier-plugin-svelte"],
   "svelteSortOrder" : "styles-scripts-markup",
   "svelteStrictMode": false,
   "svelteBracketNewLine": true,


### PR DESCRIPTION
Small PR to fix a hidden / silent `prettier` error that would not always correctly format `*.svelte` files.


```bash
["INFO" - 12:24:43 PM] Prettier Options:
{
  "filepath": "~/marketplace-games-ui/src/components/Tabs.svelte",
  "parser": "svelte",
  "plugins": ["prettier-plugin-svelte"],
  "svelteSortOrder": "styles-scripts-markup",
  "svelteStrictMode": false,
  "svelteBracketNewLine": true,
  "svelteAllowShorthand": true,
  "svelteIndentScriptAndStyle": true,
  "printWidth": 80,
  "proseWrap": "always",
  "singleQuote": true,
  "trailingComma": "es5"
}
["ERROR" - 12:14:43 PM] Error formatting document.
["ERROR" - 12:14:43 PM] Cannot find module 'prettier-plugin-svelte' from '/'
Error: Cannot find module 'prettier-plugin-svelte' from '/'
    at Function.resolveSync [as sync] (~/marketplace-games-ui/node_modules/prettier/index.js:20675:13)
    ...
```